### PR TITLE
Loader Cache Decorators

### DIFF
--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CB84D3612C45234E0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
 		CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		CB84D3652C4525DD0003722B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */; };
+		CB84D3672C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3662C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -73,6 +74,7 @@
 		CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		CB84D3662C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 			children = (
 				CB11C2BC2C42F0F90046AED1 /* XCTestCase+MemoryLeakTracking.swift */,
 				CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */,
+				CB84D3662C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift */,
 				CB11C2BF2C42FB560046AED1 /* SharedTestHelpers.swift */,
 				CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */,
 				CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */,
@@ -297,6 +300,7 @@
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
 				CB84D3652C4525DD0003722B /* FeedImageDataLoaderSpy.swift in Sources */,
+				CB84D3672C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				CB11C2B72C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				CBFC28A32C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */; };
 		CB84D3602C4522DD0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
 		CB84D3612C45234E0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
+		CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -69,6 +70,7 @@
 		CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				CBFC28A22C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift */,
 				CB11C2B62C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */,
+				CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = ApplicationAppTests;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
 				CB11C2B72C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
+				CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				CBFC28A32C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				CB11C2BE2C42F0F90046AED1 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		CB84D3522C4403AF0003722B /* ApplicationFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */; };
 		CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */; };
+		CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -64,6 +65,7 @@
 		CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApplicationFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				CB11C2BC2C42F0F90046AED1 /* XCTestCase+MemoryLeakTracking.swift */,
+				CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */,
 				CB11C2BF2C42FB560046AED1 /* SharedTestHelpers.swift */,
 				CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */,
 			);
@@ -278,6 +281,7 @@
 				CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */,
 				CB11C2BA2C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				CB11C2B52C42A9840046AED1 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */,
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
 				CB11C2B72C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */; };
 		CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */; };
 		CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */; };
+		CB84D3602C4522DD0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
+		CB84D3612C45234E0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -66,6 +68,7 @@
 		CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 				CBFC288E2C409363009A61AF /* Info.plist */,
 				CB11C2B32C42A9620046AED1 /* FeedLoaderWithFallbackComposite.swift */,
 				CB11C2B82C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */,
 			);
 			path = ApplicationApp;
 			sourceTree = "<group>";
@@ -269,6 +273,7 @@
 				CBFC28852C409362009A61AF /* ViewController.swift in Sources */,
 				CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */,
 				CB11C2B42C42A9620046AED1 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				CB84D3602C4522DD0003722B /* FeedLoaderCacheDecorator.swift in Sources */,
 				CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */,
 				CB11C2B92C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 			);
@@ -281,6 +286,7 @@
 				CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */,
 				CB11C2BA2C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				CB11C2B52C42A9840046AED1 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				CB84D3612C45234E0003722B /* FeedLoaderCacheDecorator.swift in Sources */,
 				CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */,
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
@@ -453,7 +459,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -481,7 +487,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CB84D3602C4522DD0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
 		CB84D3612C45234E0003722B /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */; };
 		CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		CB84D3652C4525DD0003722B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -71,6 +72,7 @@
 		CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 				CB84D35B2C451CA40003722B /* XCTestCase+FeedLoader.swift */,
 				CB11C2BF2C42FB560046AED1 /* SharedTestHelpers.swift */,
 				CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */,
+				CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -293,6 +296,7 @@
 				CB84D35C2C451CA40003722B /* XCTestCase+FeedLoader.swift in Sources */,
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
+				CB84D3652C4525DD0003722B /* FeedImageDataLoaderSpy.swift in Sources */,
 				CB11C2B72C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				CBFC28A32C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		CB84D3512C4403AF0003722B /* ApplicationFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */; };
 		CB84D3522C4403AF0003722B /* ApplicationFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */; };
+		CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -62,6 +63,7 @@
 		CB84D34D2C4403AF0003722B /* ApplicationFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApplicationFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApplicationFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -99,6 +101,7 @@
 			children = (
 				CB11C2BC2C42F0F90046AED1 /* XCTestCase+MemoryLeakTracking.swift */,
 				CB11C2BF2C42FB560046AED1 /* SharedTestHelpers.swift */,
+				CB84D3592C451ADA0003722B /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB84D35A2C451ADA0003722B /* FeedLoaderStub.swift in Sources */,
 				CB11C2BA2C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				CB11C2B52C42A9840046AED1 /* FeedLoaderWithFallbackComposite.swift in Sources */,
 				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		CB84D3652C4525DD0003722B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */; };
 		CB84D3672C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3662C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift */; };
+		CB84D36B2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D36A2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift */; };
+		CB84D36C2C452AAC0003722B /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D36A2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -75,6 +77,7 @@
 		CB84D3622C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CB84D3642C4525DD0003722B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		CB84D3662C4526F70003722B /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		CB84D36A2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -152,6 +155,7 @@
 				CB11C2B32C42A9620046AED1 /* FeedLoaderWithFallbackComposite.swift */,
 				CB11C2B82C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				CB84D35F2C4522DD0003722B /* FeedLoaderCacheDecorator.swift */,
+				CB84D36A2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift */,
 			);
 			path = ApplicationApp;
 			sourceTree = "<group>";
@@ -285,6 +289,7 @@
 				CB84D3602C4522DD0003722B /* FeedLoaderCacheDecorator.swift in Sources */,
 				CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */,
 				CB11C2B92C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
+				CB84D36B2C452AA90003722B /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -305,6 +310,7 @@
 				CB84D3632C4525350003722B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				CBFC28A32C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				CB11C2BE2C42F0F90046AED1 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
+				CB84D36C2C452AAC0003722B /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
+++ b/ApplicationApp/ApplicationApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		CB84D3502C4403AF0003722B /* ApplicationFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34D2C4403AF0003722B /* ApplicationFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CB84D3512C4403AF0003722B /* ApplicationFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */; };
 		CB84D3522C4403AF0003722B /* ApplicationFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */; };
 		CBFC28812C409362009A61AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28802C409362009A61AF /* AppDelegate.swift */; };
 		CBFC28832C409362009A61AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28822C409362009A61AF /* SceneDelegate.swift */; };
 		CBFC28852C409362009A61AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFC28842C409362009A61AF /* ViewController.swift */; };
@@ -60,6 +61,7 @@
 		CB11C2BF2C42FB560046AED1 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		CB84D34D2C4403AF0003722B /* ApplicationFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApplicationFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB84D34E2C4403AF0003722B /* ApplicationFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApplicationFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		CBFC287D2C409362009A61AF /* ApplicationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplicationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBFC28802C409362009A61AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBFC28822C409362009A61AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				CB11C2BB2C42F0CB0046AED1 /* Helpers */,
 				CBFC28A22C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift */,
 				CB11C2B62C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				CB84D3572C4519510003722B /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = ApplicationAppTests;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 			files = (
 				CB11C2BA2C42F00F0046AED1 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				CB11C2B52C42A9840046AED1 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				CB84D3582C4519510003722B /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				CB11C2C02C42FB560046AED1 /* SharedTestHelpers.swift in Sources */,
 				CB11C2B72C42B38C0046AED1 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				CBFC28A32C4296DB009A61AF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/ApplicationApp/ApplicationApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/ApplicationApp/ApplicationApp/FeedImageDataLoaderCacheDecorator.swift
@@ -20,9 +20,15 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             })
         }
+    }
+}
+
+private extension FeedImageDataCache {
+    func saveIgnoringResult(_ data: Data, for url: URL) {
+        save(data, for: url) { _ in }
     }
 }

--- a/ApplicationApp/ApplicationApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/ApplicationApp/ApplicationApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  ApplicationApp
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import Foundation
+import ApplicationFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        }
+    }
+}

--- a/ApplicationApp/ApplicationApp/FeedLoaderCacheDecorator.swift
+++ b/ApplicationApp/ApplicationApp/FeedLoaderCacheDecorator.swift
@@ -19,9 +19,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
+                self?.cache.saveIgnoringResult(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringResult(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/ApplicationApp/ApplicationApp/FeedLoaderCacheDecorator.swift
+++ b/ApplicationApp/ApplicationApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,27 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  ApplicationApp
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import ApplicationFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in }
+                return feed
+            })
+        }
+    }
+}

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -21,7 +21,7 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     }
 }
 
-class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {
         let (_, loader) = makeSUT()
@@ -76,34 +76,5 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
-    }
-
-    private func expect(
-        _ sut: FeedImageDataLoader,
-        toCompleteWith expectedResult: FeedImageDataLoader.Result,
-        when action: () -> Void,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let exp = expectation(description: "Wait for load completion")
-
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-            case (.failure, .failure):
-                break
-
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        action()
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,130 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import XCTest
+import ApplicationFeed
+import ApplicationApp
+
+class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+
+    init(decoratee: FeedImageDataLoader) {
+        self.decoratee = decoratee
+    }
+
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url, completion: completion)
+    }
+}
+
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_init_doesNotLoadImageData() {
+        let (_, loader) = makeSUT()
+
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+    }
+
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+
+        _ = sut.loadImageData(from: url) { _ in }
+
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+
+    func test_cancelLoadImageData_cancelsLoaderTask() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+
+        let task = sut.loadImageData(from: url) { _ in }
+        task.cancel()
+
+        XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+    }
+
+    func test_loadImageData_deliversDataOnLoaderSuccess() {
+        let imageData = anyData()
+        let (sut, loader) = makeSUT()
+
+        expect(sut, toCompleteWith: .success(imageData), when: {
+            loader.complete(with: imageData)
+        })
+    }
+
+    func test_loadImageData_deliversErrorOnLoaderFailure() {
+        let (sut, loader) = makeSUT()
+
+        expect(sut, toCompleteWith: .failure(anyNSError()), when: {
+            loader.complete(with: anyNSError())
+        })
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
+
+    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+            case (.failure, .failure):
+                break
+
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        action()
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    private class LoaderSpy: FeedImageDataLoader {
+        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+        private(set) var cancelledURLs = [URL]()
+
+        var loadedURLs: [URL] {
+            return messages.map { $0.url }
+        }
+
+        private struct Task: FeedImageDataLoaderTask {
+            let callback: () -> Void
+            func cancel() { callback() }
+        }
+
+        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+            messages.append((url, completion))
+            return Task { [weak self] in
+                self?.cancelledURLs.append(url)
+            }
+        }
+
+        func complete(with error: Error, at index: Int = 0) {
+            messages[index].completion(.failure(error))
+        }
+
+        func complete(with data: Data, at index: Int = 0) {
+            messages[index].completion(.success(data))
+        }
+    }
+}

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,24 +9,6 @@ import XCTest
 import ApplicationFeed
 import ApplicationApp
 
-class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-    
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        }
-    }
-}
-
 class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -25,8 +25,10 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     }
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
-            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
-            completion(result)
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
         }
     }
 }
@@ -85,6 +87,17 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTes
         loader.complete(with: imageData)
         
         XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
+    func test_loadImageData_doesNotCacheDataOnLoaderFailure() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: anyNSError())
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache image data on load error")
     }
     
     // MARK: - Helpers

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -67,15 +67,24 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
-        let loader = LoaderSpy()
+    private func makeSUT(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
     }
 
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+    private func expect(
+        _ sut: FeedImageDataLoader,
+        toCompleteWith expectedResult: FeedImageDataLoader.Result,
+        when action: () -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
         let exp = expectation(description: "Wait for load completion")
 
         _ = sut.loadImageData(from: anyURL()) { receivedResult in
@@ -96,35 +105,5 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         action()
 
         wait(for: [exp], timeout: 1.0)
-    }
-
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-
-        private(set) var cancelledURLs = [URL]()
-
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() { callback() }
-        }
-
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,12 +9,6 @@ import XCTest
 import ApplicationFeed
 import ApplicationApp
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
     private let cache: FeedImageDataCache

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,15 +9,25 @@ import XCTest
 import ApplicationFeed
 import ApplicationApp
 
+protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
-
-    init(decoratee: FeedImageDataLoader) {
+    private let cache: FeedImageDataCache
+    
+    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
-
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url, completion: completion)
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -64,17 +74,43 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTes
             loader.complete(with: anyNSError())
         })
     }
-
+    
+    func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let imageData = anyData()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: imageData)
+        
+        XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
     // MARK: - Helpers
 
     private func makeSUT(
+        cache: CacheSpy = .init(),
         file: StaticString = #file,
         line: UInt = #line
     ) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
         let loader = FeedImageDataLoaderSpy()
-        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
+    }
+    
+    private class CacheSpy: FeedImageDataCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save(data: Data, for: URL)
+        }
+        
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+            messages.append(.save(data: data, for: url))
+            completion(.success(()))
+        }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import ApplicationFeed
 
-class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {
         let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -103,34 +103,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private func expect(
-        _ sut: FeedImageDataLoader,
-        toCompleteWith expectedResult: FeedImageDataLoader.Result,
-        when action: () -> Void,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -92,9 +92,12 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -102,7 +105,13 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         return (sut, primaryLoader, fallbackLoader)
     }
     
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+    private func expect(
+        _ sut: FeedImageDataLoader,
+        toCompleteWith expectedResult: FeedImageDataLoader.Result,
+        when action: () -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
         let exp = expectation(description: "Wait for load completion")
         
         _ = sut.loadImageData(from: anyURL()) { receivedResult in
@@ -123,35 +132,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         action()
         
         wait(for: [exp], timeout: 1.0)
-    }
-    
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        
-        private(set) var cancelledURLs = [URL]()
-
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() { callback() }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ final class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
+            completion(result.map { feed in
                 self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+                return feed
+            })
         }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -59,8 +59,4 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
         wait(for: [exp], timeout: 1.0)
     }
-
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,7 +25,9 @@ final class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            self?.cache.save((try? result.get()) ?? []) { _ in }
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
             completion(result)
         }
     }
@@ -54,6 +56,15 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         sut.load { _ in }
         
         XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
+    
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache feed on load error")
     }
     
     // MARK: - Helpers

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ final class FeedLoaderCacheDecorator: FeedLoader {
     }
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -35,28 +35,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
-    }
-
-    // MARK: - Helpers
-
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-            case (.failure, .failure):
-                break
-
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,80 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import XCTest
+import ApplicationFeed
+
+final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .success(feed))
+    }
+
+    func test_load_deliversErrorOnLoaderFailure() {
+        let loader = LoaderStub(result: .failure(anyNSError()))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+
+    // MARK: - Helpers
+
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+            case (.failure, .failure):
+                break
+
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+    }
+
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+
+
+}

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import ApplicationFeed
 
+protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
 final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
-
-    init(decoratee: FeedLoader) {
+    private let cache: FeedCache
+    
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
-
+    
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            self?.cache.save((try? result.get()) ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -35,14 +46,41 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         expect(sut, toCompleteWith: .failure(anyNSError()))
     }
     
+    func test_load_cachesLoadedFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
     
     // MARK: - Helpers
 
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+    private func makeSUT(
+        loaderResult: FeedLoader.Result,
+        cache: CacheSpy = .init(),
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
+    }
+    
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+        
+        func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,16 +24,25 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
 
         expect(sut, toCompleteWith: .success(feed))
     }
 
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = FeedLoaderStub(result: .failure(anyNSError()))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    
+    // MARK: - Helpers
+
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return sut
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import ApplicationFeed
-
-final class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-    
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
-                return feed
-            })
-        }
-    }
-}
+import ApplicationApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import ApplicationFeed
 
-protocol FeedCache {
-    typealias Result = Swift.Result<Void, Error>
-
-    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,14 +24,14 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .success(feed))
     }
 
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = LoaderStub(result: .failure(anyNSError()))
+        let loader = FeedLoaderStub(result: .failure(anyNSError()))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -63,18 +63,4 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
     }
-
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
-    }
-
-
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -63,8 +63,4 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -34,8 +34,8 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     // MARK: - Helpers
     
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -66,18 +66,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-
-        }
     }
 }

--- a/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/ApplicationApp/ApplicationAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import ApplicationFeed
 
-class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -41,26 +41,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/ApplicationApp/ApplicationAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/ApplicationApp/ApplicationAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,39 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import Foundation
+import ApplicationFeed
+
+class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+    private(set) var cancelledURLs = [URL]()
+
+    var loadedURLs: [URL] {
+        return messages.map { $0.url }
+    }
+
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        func cancel() { callback() }
+    }
+
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+
+    func complete(with error: Error, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+
+    func complete(with data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+}

--- a/ApplicationApp/ApplicationAppTests/Helpers/FeedLoaderStub.swift
+++ b/ApplicationApp/ApplicationAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,20 @@
+//
+//  FeedLoaderStub.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import ApplicationFeed
+
+class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/ApplicationApp/ApplicationAppTests/Helpers/SharedTestHelpers.swift
+++ b/ApplicationApp/ApplicationAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import ApplicationFeed
 
 func anyNSError() -> NSError {
     return NSError(domain: "any error", code: 0)
@@ -17,4 +18,8 @@ func anyURL() -> URL {
 
 func anyData() -> Data {
     return Data("any data".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
 }

--- a/ApplicationApp/ApplicationAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/ApplicationApp/ApplicationAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,42 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import XCTest
+import ApplicationFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+    func expect(
+        _ sut: FeedImageDataLoader,
+        toCompleteWith expectedResult: FeedImageDataLoader.Result,
+        when action: () -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        action()
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/ApplicationApp/ApplicationAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/ApplicationApp/ApplicationAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,34 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  ApplicationAppTests
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import XCTest
+import ApplicationFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/ApplicationFeed/ApplicationFeed.xcodeproj/project.pbxproj
+++ b/ApplicationFeed/ApplicationFeed.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		CB7E97F62B0AF2D400CF676B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFCB4E32B00360C0059B310 /* SharedTestHelpers.swift */; };
 		CB7E97F72B0AF2E900CF676B /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFCB4E12B0034ED0059B310 /* FeedCacheTestHelpers.swift */; };
 		CB84D35E2C45222F0003722B /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35D2C45222F0003722B /* FeedCache.swift */; };
+		CB84D3692C4529B20003722B /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D3682C4529B20003722B /* FeedImageDataCache.swift */; };
 		CBACD5892AF3111000F7DA05 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBACD5882AF3111000F7DA05 /* RemoteFeedItem.swift */; };
 		CBACD58B2AF311EB00F7DA05 /* LocalFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBACD58A2AF311EB00F7DA05 /* LocalFeedImage.swift */; };
 		CBB0E3DF2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB0E3DE2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -205,6 +206,7 @@
 		CB7E97EA2B0AEDA900CF676B /* ApplicationFeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplicationFeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB7E97EC2B0AEDA900CF676B /* ApplicationFeedCacheIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationFeedCacheIntegrationTests.swift; sourceTree = "<group>"; };
 		CB84D35D2C45222F0003722B /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
+		CB84D3682C4529B20003722B /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		CBACD5882AF3111000F7DA05 /* RemoteFeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedItem.swift; sourceTree = "<group>"; };
 		CBACD58A2AF311EB00F7DA05 /* LocalFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImage.swift; sourceTree = "<group>"; };
 		CBB0E3DE2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				CBDD84182AD9FF4A00E20A5B /* FeedLoader.swift */,
 				CBFD64EA2B1688F1003BCE1C /* FeedImageDataLoader.swift */,
 				CB84D35D2C45222F0003722B /* FeedCache.swift */,
+				CB84D3682C4529B20003722B /* FeedImageDataCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -953,6 +956,7 @@
 				CB7E97B92B050F3500CF676B /* FeedCachePolicy.swift in Sources */,
 				CB6F29D42B38852700C2C613 /* FeedPresenter.swift in Sources */,
 				CBD9AF752AD9FDA400ECCC91 /* FeedImage.swift in Sources */,
+				CB84D3692C4529B20003722B /* FeedImageDataCache.swift in Sources */,
 				CB7E97E52B0A88DB00CF676B /* ManagedFeedImage.swift in Sources */,
 				CBF8260B2B389AF400BF9EE8 /* FeedImageViewModel.swift in Sources */,
 				CBC15EA82B45F6FA005FF3A3 /* RemoteFeedImageDataLoader.swift in Sources */,

--- a/ApplicationFeed/ApplicationFeed.xcodeproj/project.pbxproj
+++ b/ApplicationFeed/ApplicationFeed.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		CB7E97F52B0AF12100CF676B /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB0E3DE2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift */; };
 		CB7E97F62B0AF2D400CF676B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFCB4E32B00360C0059B310 /* SharedTestHelpers.swift */; };
 		CB7E97F72B0AF2E900CF676B /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFCB4E12B0034ED0059B310 /* FeedCacheTestHelpers.swift */; };
+		CB84D35E2C45222F0003722B /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84D35D2C45222F0003722B /* FeedCache.swift */; };
 		CBACD5892AF3111000F7DA05 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBACD5882AF3111000F7DA05 /* RemoteFeedItem.swift */; };
 		CBACD58B2AF311EB00F7DA05 /* LocalFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBACD58A2AF311EB00F7DA05 /* LocalFeedImage.swift */; };
 		CBB0E3DF2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB0E3DE2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -203,6 +204,7 @@
 		CB7E97E42B0A88DB00CF676B /* ManagedFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedFeedImage.swift; sourceTree = "<group>"; };
 		CB7E97EA2B0AEDA900CF676B /* ApplicationFeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplicationFeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB7E97EC2B0AEDA900CF676B /* ApplicationFeedCacheIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationFeedCacheIntegrationTests.swift; sourceTree = "<group>"; };
+		CB84D35D2C45222F0003722B /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		CBACD5882AF3111000F7DA05 /* RemoteFeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedItem.swift; sourceTree = "<group>"; };
 		CBACD58A2AF311EB00F7DA05 /* LocalFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImage.swift; sourceTree = "<group>"; };
 		CBB0E3DE2AE45F860064DBB1 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				CBD9AF742AD9FDA400ECCC91 /* FeedImage.swift */,
 				CBDD84182AD9FF4A00E20A5B /* FeedLoader.swift */,
 				CBFD64EA2B1688F1003BCE1C /* FeedImageDataLoader.swift */,
+				CB84D35D2C45222F0003722B /* FeedCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -945,6 +948,7 @@
 				CBDD842C2ADC5FA200E20A5B /* FeedItemsMapper.swift in Sources */,
 				CBACD5892AF3111000F7DA05 /* RemoteFeedItem.swift in Sources */,
 				CBC7CCC22B6F093200BF0428 /* FeedImageDataStore.swift in Sources */,
+				CB84D35E2C45222F0003722B /* FeedCache.swift in Sources */,
 				CBC15EAB2B45FEB0005FF3A3 /* HTTPURLResponse+StatusCode.swift in Sources */,
 				CB7E97B92B050F3500CF676B /* FeedCachePolicy.swift in Sources */,
 				CB6F29D42B38852700C2C613 /* FeedPresenter.swift in Sources */,

--- a/ApplicationFeed/ApplicationFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/ApplicationFeed/ApplicationFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -15,8 +15,8 @@ public final class LocalFeedImageDataLoader {
     }
 }
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Result<Void, Swift.Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
     
     public enum SaveError: Error {
         case failed

--- a/ApplicationFeed/ApplicationFeed/Feed Cache/LocalFeedLoader.swift
+++ b/ApplicationFeed/ApplicationFeed/Feed Cache/LocalFeedLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedLoader {
     }
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.Result
     
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in

--- a/ApplicationFeed/ApplicationFeed/Feed Feature/FeedCache.swift
+++ b/ApplicationFeed/ApplicationFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  ApplicationFeed
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/ApplicationFeed/ApplicationFeed/Feed Feature/FeedImageDataCache.swift
+++ b/ApplicationFeed/ApplicationFeed/Feed Feature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  ApplicationFeed
+//
+//  Created by Kantemir Vologirov on 15.7.24..
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added LoaderCacheDecorators responsible for decorating (intercepting) load operations and injecting the save side-effect on successful load results.

We can now use the decorators to compose the RemoteFeedLoader.loadwith the LocalFeedLoader.save operations in a simple, clean, extendable, modular, and testable way.